### PR TITLE
Fix import path for SolutionSection

### DIFF
--- a/app/components/sections/PasSlab.tsx
+++ b/app/components/sections/PasSlab.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
-import SolutionSection from '../sections/SolutionSection';
+import SolutionSection from './SolutionSection';
 import TypeformPopup from '../ui/TypeformPopup';
 
 const PasSlab = () => {


### PR DESCRIPTION
This PR fixes the import path in PasSlab.tsx. The previous fix was incorrect because it was using '../sections/SolutionSection' when both files are in the same directory. This change fixes the build errors.