### PR TITLE
Configure static asset caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ npm start
 - Brand colors and typography defined in `tailwind.config.js`
 - Component styles follow consistent patterns
 - Section content can be easily modified in respective component files 
+## Static Asset Caching
+
+Static assets with hashed filenames (e.g., `logo.abcd1234.png`) are served with long-term caching. The production server sets `Cache-Control: public, max-age=31536000, immutable` for files under `/_next/static` and any hashed files in `public/`.
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,27 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/_next/static/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        source: '/:path*\\.[0-9a-fA-F]{8}\\.(png|jpg|jpeg|gif|svg|webp|ico|js|css)$',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- configure long-term caching for static assets with hashed names
- document hashed static asset caching in README

## Testing
- `npm run build`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6849f41beb048322971c85a987eadbd5